### PR TITLE
[Sidebar] "Open site directory" feature

### DIFF
--- a/Sidebar/SidebarPlugin.py
+++ b/Sidebar/SidebarPlugin.py
@@ -175,6 +175,7 @@ class UiWebsocketPlugin(object):
               {_[Files]}
               <a href='/list/{site.address}' class='link-right link-outline' id="browse-files">{_[Browse files]}</a>
               <small class="label-right">
+               <a href='#Site+directory' id='link-directory' class='link-right'>{_[Open site directory]}</a>
                <a href='/ZeroNet-Internal/Zip?address={site.address}' id='link-zip' class='link-right' download='site.zip'>{_[Save as .zip]}</a>
               </small>
              </label>


### PR DESCRIPTION
The legacy HelloZeroNet has a feature [Open site directory] in Sidebar. It has been removed when [added [Browse files] feature](https://github.com/zeronet-conservancy/zeronet-conservancy/commit/52ed8c18ca0f009e3fe327fe35fc9995b044d70c). But that was convenient to open directory in system file manager.